### PR TITLE
[1] Add wave samples to build workflow

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,8 @@ else()
     message(STATUS "Using double precision floats")
 endif()
 
+target_compile_definitions(pal_platform_defs INTERFACE PAL_AUDIO_SAMPLE_RATE=${PAL_AUDIO_SAMPLE_RATE})
+
 if("${PAL_BACKEND_SOURCES}" STREQUAL "")
     message(FATAL_ERROR "PAL Backend not set! Before including PAL as a subdirectory, make sure to set the PAL_BACKEND_SOURCES variable to the source that implements PAL functions.")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,15 +16,17 @@ if("${PAL_BACKEND_SOURCES}" STREQUAL "")
     message(FATAL_ERROR "PAL Backend not set! Before including PAL as a subdirectory, make sure to set the PAL_BACKEND_SOURCES variable to the source that implements PAL functions.")
 endif()
 
-set(CMAKE_CXX_FLAGS_DEBUG "-g")
+set(CMAKE_CXX_FLAGS_DEBUG "-Og -g")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3")
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/generate_sprites.cmake)
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/generate_midi.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/generate_wav.cmake)
 
-# Generate midi and sprite .c/.h files
+# Generate midi, wave sample, and sprite .c/.h files
 generate_midi("${MIDI_FILES}" ${CMAKE_CURRENT_BINARY_DIR}/src/assets/midi ${CMAKE_CURRENT_BINARY_DIR}/include/assets/midi GENERATED_MIDI_C_FILES)
+generate_wav("${WAV_FILES}" ${CMAKE_CURRENT_BINARY_DIR}/src/assets/samples ${CMAKE_CURRENT_BINARY_DIR}/include/assets/samples GENERATED_WAV_C_FILES)
 generate_sprites("${SPRITE_FILES}" ${CMAKE_CURRENT_BINARY_DIR}/src/assets/sprites ${CMAKE_CURRENT_BINARY_DIR}/include/assets/sprites GENERATED_SPRITE_C_FILES)
 
 add_library(pal_engine
@@ -41,10 +43,11 @@ add_library(pal_engine
     src/queue.c
     ${PAL_BACKEND_SOURCES}
     ${GENERATED_MIDI_C_FILES}
+    ${GENERATED_WAV_C_FILES}
     ${GENERATED_SPRITE_C_FILES}
 )
 
-add_dependencies(pal_engine generated_midi_files generated_sprite_files)
+add_dependencies(pal_engine generated_midi_files generated_wav_files generated_sprite_files)
 
 target_include_directories(pal_engine PUBLIC include ${CMAKE_CURRENT_BINARY_DIR}/include ${PAL_BACKEND_INCLUDES})
 

--- a/cmake/generate_wav.cmake
+++ b/cmake/generate_wav.cmake
@@ -1,0 +1,34 @@
+function(generate_wav WAV_FILES OUTPUT_SRC_DIR OUTPUT_INC_DIR OUTPUT_SOURCE_FILES_LIST)
+    include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/util.cmake)
+
+    # Make the desired output directories
+    file(MAKE_DIRECTORY ${OUTPUT_SRC_DIR})
+    file(MAKE_DIRECTORY ${OUTPUT_INC_DIR})
+
+    # Setup python venv stuff
+    set(WAV_TO_C ${UTIL_DIR}/wav_to_c.py)
+
+    # Iterate over each wave file
+    foreach(WAV_FILE ${WAV_FILES})
+        # Get the stem (filename without extension) of the wave file
+        get_filename_component(WAV_STEM ${WAV_FILE} NAME_WE)
+        # Construct the output filenames for the generated C and H files
+        set(WAV_C_FILE ${OUTPUT_SRC_DIR}/${WAV_STEM}.c)
+        set(WAV_H_FILE ${OUTPUT_INC_DIR}/${WAV_STEM}.h)
+        # Add a custom command to run the Python script for each wave file
+        add_custom_command(
+            OUTPUT ${WAV_C_FILE} ${WAV_H_FILE}
+            COMMAND ${UTIL_PYTHON} ${WAV_TO_C} ${WAV_FILE} ${PAL_AUDIO_SAMPLE_RATE} ${OUTPUT_SRC_DIR} ${OUTPUT_INC_DIR} "assets/samples"
+            DEPENDS ${WAV_FILE}
+            COMMENT "Generating wave sample .c and .h files for ${WAV_FILE}"
+        )
+        # Collect the output files
+        list(APPEND GENERATED_WAV_C_FILES ${WAV_C_FILE})
+        list(APPEND GENERATED_WAV_H_FILES ${WAV_H_FILE})
+    endforeach()
+
+    add_custom_target(generated_wav_files DEPENDS ${GENERATED_WAV_C_FILES} ${GENERATED_WAV_H_FILES})
+
+    # send list out to function caller
+    set(${OUTPUT_SOURCE_FILES_LIST} ${GENERATED_WAV_C_FILES} PARENT_SCOPE)
+endfunction()

--- a/cmake/util.cmake
+++ b/cmake/util.cmake
@@ -1,2 +1,2 @@
 set(UTIL_DIR ${CMAKE_CURRENT_SOURCE_DIR}/util)
-set(UTIL_PYTHON ${CMAKE_CURRENT_SOURCE_DIR}/util/.venv/bin/python)
+set(UTIL_PYTHON ${UTIL_DIR}/.venv/bin/python)

--- a/include/midi_parse.h
+++ b/include/midi_parse.h
@@ -56,6 +56,7 @@ enum midi_meta_event_code {
     MIDI_META_EVENT_CHANNEL_PREFIX =         0x20,
     MIDI_META_EVENT_END_OF_TRACK =           0x2F,
     MIDI_META_EVENT_SET_TEMPO =              0x51,
+    MIDI_META_EVENT_SMPTE_OFFSET =           0x54,
     MIDI_META_EVENT_TIME_SIGNATURE =         0x58,
     MIDI_META_EVENT_KEY_SIGNATURE =          0x59,
     MIDI_META_EVENT_SEQUENCER_SPECIFIC =     0x7F,
@@ -85,7 +86,7 @@ union status_byte {
 
 struct track {
     uint8_t *pointer;
-    int64_t timer; // down counter until next event
+    int64_t timer; // nanosecond down counter until next event
     bool ended;
     union status_byte previous_status;
     uint8_t channel_prefix;
@@ -121,7 +122,7 @@ struct midi_parser {
     bool loop; // whether or not to loop midi playback when end is reached
     uint16_t num_tracks;
     uint32_t tempo_us_per_quarter_note;
-    uint32_t us_per_tick;
+    uint32_t ns_per_tick;
     union {
         struct {
             uint16_t ticks_per_frame : 8;
@@ -160,14 +161,14 @@ bool midi_parser_init(struct midi_parser *parser, void *buffer);
 void midi_parser_restart(struct midi_parser *parser);
 
 /**
- * @brief Advances parser by given time delta
+ * @brief Advances parser by given time delta in nanoseconds
  *
  * @param parser
- * @param delta_time_us
+ * @param delta_time_ns
  * @return true event needs to be read
  * @return false no events pending
  */
-bool midi_parser_advance(struct midi_parser *parser, uint32_t delta_time_us);
+bool midi_parser_advance(struct midi_parser *parser, uint32_t delta_time_ns);
 
 /**
  * @brief Gets pending event from parser
@@ -194,3 +195,12 @@ pal_float_t midi_parser_note_frequency(uint8_t note_number);
  * @return false
  */
 bool midi_parser_ended(struct midi_parser *parser);
+
+/**
+ * @brief Sets track offset to given initial time offset value in seconds
+ *
+ * @param parser
+ * @param track_num
+ * @param initial_value initial time offset in seconds
+ */
+void midi_parser_set_track_offset(struct midi_parser *parser, int track_num, pal_float_t initial_value);

--- a/include/pal.h
+++ b/include/pal.h
@@ -39,7 +39,6 @@ typedef void (*pal_audio_callback_t)(audio_sample_t *samples, int num_samples);
 // Screen size must be set in pal.c depending on actual/window screen dimensions
 extern const screen_dim_t PAL_SCREEN_WIDTH;
 extern const screen_dim_t PAL_SCREEN_HEIGHT;
-extern uint32_t PAL_AUDIO_SAMPLE_RATE;
 extern const uint32_t PAL_RAND_MAX;
 
 

--- a/util/requirements.txt
+++ b/util/requirements.txt
@@ -1,2 +1,3 @@
 click
 pillow
+scipy


### PR DESCRIPTION
This PR adds wave sample generation to the cmake build workflow similarly to how sprites and midi files are included as part of the compiled binary.

- Updated wav_to_c with command line args that better fit cmake
- Added generate_wav.cmake to move wave files into compiled binary
- Added wave file generation to build stage
- Moved PAL_AUDIO_SAMPLE_RATE into cmake defined variable
- Added wave sampler, changed midi time deltas to be nanoseconds